### PR TITLE
여러 레포지터리를 지원하기위한 UoW 일반화 

### DIFF
--- a/fastmsa/event.py
+++ b/fastmsa/event.py
@@ -40,7 +40,7 @@ class MessageBus:
     ):
         self.event_handlers, self.command_handlers = handlers
 
-    def handle(self, message: Message, uow: AbstractUnitOfWork[T]):  # type: ignore
+    def handle(self, message: Message, uow: AbstractUnitOfWork):  # type: ignore
         queue = [message]
         results = []
 

--- a/fastmsa/templates/app/app/services/sample.py
+++ b/fastmsa/templates/app/app/services/sample.py
@@ -13,14 +13,14 @@ def add_item(
     uuid: str,
     product_id: str,
     created: Optional[datetime],
-    uow: AbstractUnitOfWork[Product],
+    uow: AbstractUnitOfWork,
 ) -> None:
     """Item을 추가합니다."""
     with uow:
-        product = uow.repo.get(id)
+        product = uow[Product].get(id)
 
         if not product:
             product = Product(id, items=[])
-            uow.repo.add(product)
+            uow[Product].add(product)
         product.items.append(Item(id, uuid, product_id, created or datetime.now()))
         uow.commit()

--- a/fastmsa/uow.py
+++ b/fastmsa/uow.py
@@ -13,19 +13,19 @@ from __future__ import annotations
 
 import abc
 from contextlib import AbstractContextManager
-from typing import Any, Generic, Optional, Type, TypeVar
+from typing import Any, Generic, Optional, Protocol, Sequence, Type, TypeVar
 
-from sqlalchemy.orm import Session
-
+from fastmsa.core import FastMSAError
 from fastmsa.domain import Aggregate, Entity
-from fastmsa.orm import SessionMaker, get_sessionmaker
+from fastmsa.orm import SessionMaker, get_sessionmaker, Session
 from fastmsa.repo import AbstractRepository, SqlAlchemyRepository
 
+T = TypeVar("T")
 E = TypeVar("E", bound=Entity)
 A = TypeVar("A", bound=Aggregate)
 
 
-class AbstractUnitOfWork(Generic[A], AbstractContextManager[Session]):
+class AbstractUnitOfWorkOld(Generic[A], AbstractContextManager[Session]):
     """UnitOfWork 패턴의 추상 인터페이스입니다.
 
     UnitOfWork(UoW)는 영구 저장소의 유일한 진입점이며, 로드된 객체의
@@ -34,7 +34,7 @@ class AbstractUnitOfWork(Generic[A], AbstractContextManager[Session]):
 
     repo: AbstractRepository[A]
 
-    def __enter__(self) -> AbstractUnitOfWork[A]:
+    def __enter__(self) -> AbstractUnitOfWorkOld[A]:
         """``with`` 블록에 진입했을때 실행되는 메소드입니다."""
         return self
 
@@ -63,7 +63,7 @@ class AbstractUnitOfWork(Generic[A], AbstractContextManager[Session]):
         raise NotImplementedError
 
 
-class SqlAlchemyUnitOfWork(AbstractUnitOfWork[A]):  # type: ignore
+class SqlAlchemyUnitOfWorkOld(AbstractUnitOfWorkOld[A]):  # type: ignore
     """``SqlAlchemy`` ORM을 이용한 UnitOfWork 패턴 구현입니다."""
 
     # pylint: disable=super-init-not-called
@@ -91,7 +91,7 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork[A]):  # type: ignore
     def __repr__(self):
         return f"SqlAlchemyUnitOfWork[{self.agg_class}]"
 
-    def __enter__(self) -> AbstractUnitOfWork[A]:
+    def __enter__(self) -> AbstractUnitOfWorkOld[A]:
         """``with`` 블록에 진입했을 때 필요한 작업을 수행합니다.
 
         세션을 할당하고, ``batches`` 레포지터리를 초기화합니다.
@@ -102,6 +102,125 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork[A]):  # type: ignore
             self.session,
         )
         return super().__enter__()
+
+    def __exit__(self, *args: Any) -> None:
+        """``with`` 블록을 빠져나갈 때 필요한 작업을 수행합니다.
+
+        세션을 close합니다.
+        """
+        super().__exit__(*args)
+        if self.session:
+            self.session.close()
+
+    def _commit(self) -> None:
+        """세션을 커밋합니다."""
+        self.committed = True
+        if self.session:
+            self.session.commit()
+
+    def rollback(self) -> None:
+        """세션을 롤백합니다."""
+        if self.session:
+            self.session.rollback()
+
+
+AggregateReposMap = dict[Type[Aggregate], AbstractRepository]
+
+
+class AbstractUowProtocol(Protocol):
+    repos: AggregateReposMap
+    agg_classes: Sequence[Type[Aggregate]]
+
+
+class AggregateCallable(Protocol):
+    def __call__(self, *args: Type[Aggregate]) -> AbstractUnitOfWork:
+        ...
+
+
+class AbstractUnitOfWork(AbstractUowProtocol, AbstractContextManager[Session]):
+    """UnitOfWork 패턴의 추상 인터페이스입니다.
+
+    UnitOfWork(UoW)는 영구 저장소의 유일한 진입점이며, 로드된 객체의
+    최신 상태를 계속 트래킹 합니다.
+    """
+
+    repos: AggregateReposMap
+
+    def __enter__(self) -> AbstractUnitOfWork:
+        """``with`` 블록에 진입했을때 실행되는 메소드입니다."""
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """``with`` 블록에서 빠져나갈 때 실행되는 메소드입니다."""
+        self.rollback()  # commit() 안되었을때 변경을 롤백합니다.
+        # (이미 커밋 되었을 경우 rollback은 아무 효과도 없음)
+
+    def __getitem__(self, key: Type[A]) -> AbstractRepository[A]:
+        if key not in self.repos:
+            raise FastMSAError("repostory not found for: %r" % key)
+        return self.repos[key]
+
+    def commit(self) -> None:
+        """세션을 커밋합니다."""
+        self._commit()
+
+    def collect_new_messages(self):
+        """처리된 Aggregate 객체에 추가된 이벤트를 수집합니다."""
+        for repo in self.repos.values():
+            for agg in repo.seen:
+                while agg.messages:
+                    yield agg.messages.pop(0)
+
+    @abc.abstractmethod
+    def _commit(self) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def rollback(self) -> None:
+        """세션을 롤백합니다."""
+        raise NotImplementedError
+
+
+class SqlAlchemyUnitOfWork(AbstractUnitOfWork):  # type: ignore
+    """``SqlAlchemy`` ORM을 이용한 UnitOfWork 패턴 구현입니다."""
+
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        agg_classes: Sequence[Type[Aggregate]],
+        get_session: Optional[SessionMaker] = None,
+    ) -> None:
+        """``SqlAlchemy`` 기반의 UoW를 초기화합니다."""
+        super().__init__()
+        self.agg_classes = agg_classes
+        self.repos: AggregateReposMap = {}
+
+        if not get_session:
+            self.get_session = get_sessionmaker()
+        else:
+            self.get_session = get_session
+
+        self.committed = False
+        self.session: Optional[Session] = None
+
+    def __repr__(self):
+        return f"SqlAlchemyUnitOfWork[{self.repos}]"
+
+    def __enter__(self) -> AbstractUnitOfWork:
+        """``with`` 블록에 진입했을 때 필요한 작업을 수행합니다.
+
+        세션을 할당하고, ``batches`` 레포지터리를 초기화합니다.
+        """
+        self.session = self.get_session()
+        for agg_class in self.agg_classes:
+            if agg_class in self.repos:
+                continue  # already initalized
+
+            self.repos[agg_class] = SqlAlchemyRepository(
+                agg_class,
+                self.session,
+            )
+        return self
 
     def __exit__(self, *args: Any) -> None:
         """``with`` 블록을 빠져나갈 때 필요한 작업을 수행합니다.

--- a/tests/app/routes/fastapi.py
+++ b/tests/app/routes/fastapi.py
@@ -14,7 +14,7 @@ from tests.app.schema.batch import BatchAddSchema, BatchAllocateSchema
 def add_batch(batch: BatchAddSchema):
     """``POST /batches`` 요청을 처리하여 새로운 배치를 저장소에 추가합니다."""
     event = commands.CreateBatch(batch.ref, batch.sku, batch.qty, batch.eta)
-    messagebus.handle(event, SqlAlchemyUnitOfWork(Product))
+    messagebus.handle(event, SqlAlchemyUnitOfWork([Product]))
 
 
 @app.post("/batches/allocate", status_code=201)
@@ -22,7 +22,7 @@ def post_allocate_batch(req: BatchAllocateSchema):
     """``POST /allocate`` 엔트포인트 요청을 처리합니다."""
     try:
         event = commands.Allocate(req.orderid, req.sku, req.qty)
-        results = messagebus.handle(event, SqlAlchemyUnitOfWork(Product))
+        results = messagebus.handle(event, SqlAlchemyUnitOfWork([Product]))
         return {"batchref": results.pop(0)}
     except InvalidSku as e:
         return {"batchref": None, "error": "InvalidSku"}

--- a/tests/app/services/batch.py
+++ b/tests/app/services/batch.py
@@ -25,25 +25,21 @@ def is_valid_sku(sku: str, batches: Sequence[Batch]) -> bool:
 
 
 def add_batch(
-    ref: str,
-    sku: str,
-    qty: int,
-    eta: Optional[date],
-    uow: AbstractUnitOfWork[Product],
+    ref: str, sku: str, qty: int, eta: Optional[date], uow: AbstractUnitOfWork
 ) -> None:
     """UOW를 이용해 배치를 추가합니다."""
     with uow:
-        product = uow.repo.get(sku)
+        product = uow[Product].get(sku)
 
         if not product:
             product = Product(sku, items=[])
-            uow.repo.add(product)
+            uow[Product].add(product)
         product.items.append(Batch(ref, sku, qty, eta))
         uow.commit()
 
 
 def allocate(
-    orderid: str, sku: str, qty: int, uow: AbstractUnitOfWork[Product]
+    orderid: str, sku: str, qty: int, uow: AbstractUnitOfWork
 ) -> Optional[str]:
     """ETA가 가장 빠른 배치를 찾아 :class:`.OrderLine` 을 할당합니다.
 
@@ -52,7 +48,7 @@ def allocate(
     """
     line = OrderLine(orderid, sku, qty)
     with uow:
-        product = uow.repo.get(line.sku)
+        product = uow[Product].get(line.sku)
         if product is None:
             raise InvalidSku(f"Invalid sku {line.sku}")
         batchref = product.allocate(line)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,8 +77,8 @@ def get_repo(get_session: SessionMaker) -> SqlAlchemyRepoMaker:
 
 
 @pytest.fixture
-def get_uow(get_session: SessionMaker) -> Callable[[], AbstractUnitOfWork[Product]]:
-    return lambda: SqlAlchemyUnitOfWork(Product, get_session)
+def get_uow(get_session: SessionMaker) -> Callable[[], AbstractUnitOfWork]:
+    return lambda: SqlAlchemyUnitOfWork([Product], get_session)
 
 
 def init_handlers() -> MessageHandlers:

--- a/tests/integration/test_uow.py
+++ b/tests/integration/test_uow.py
@@ -71,7 +71,7 @@ def cleanup_uow(get_session):
         _batch_ref = ref
         _sku = sku
         delete_product_batch_and_allocation(session, sku, _batch_ref)
-        return SqlAlchemyUnitOfWork(Product, lambda: session)
+        return SqlAlchemyUnitOfWork([Product], lambda: session)
 
     yield wrapper
 
@@ -97,10 +97,10 @@ def test_uow_can_retrieve_a_batch_and_allocate_to_it(
 ):
     ref, sku = random_batchref(), random_sku()
     session = session_with_product(ref, sku, 100, None)
-    uow = SqlAlchemyUnitOfWork(Product, get_session)
+    uow = SqlAlchemyUnitOfWork([Product], get_session)
 
     with uow:
-        product = uow.repo.get(sku)
+        product = uow[Product].get(sku)
         if product:
             line = OrderLine("o1", sku, 10)
             product.allocate(line)

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -8,8 +8,6 @@ from tests.app.domain import commands, events
 from tests.app.domain.aggregates import Product
 from tests.app.handlers import batch
 
-FakeProductUnitOfWork = FakeUnitOfWork[Product]
-
 
 class FakeProductRepository(FakeRepository[Product]):
     def _get_by_batchref(self, batchref):
@@ -25,44 +23,44 @@ def repo():
 
 @pytest.fixture
 def uow(handlers: MessageHandlers, repo: FakeProductRepository):
-    return FakeUnitOfWork(Product, repo=repo)
+    return FakeUnitOfWork(repos={Product: repo})
 
 
 class TestAddBatch:
-    def test_for_new_product(self, uow: FakeProductUnitOfWork):
+    def test_for_new_product(self, uow: FakeUnitOfWork):
         messagebus.handle(
             commands.CreateBatch("b1", "CRUNCHY-ARMCHAIR", 100, None), uow
         )
-        assert uow.repo.get("CRUNCHY-ARMCHAIR") is not None
+        assert uow[Product].get("CRUNCHY-ARMCHAIR") is not None
         assert uow.committed
 
-    def test_for_existing_product(self, uow: FakeProductUnitOfWork):
+    def test_for_existing_product(self, uow: FakeUnitOfWork):
         messagebus.handle(commands.CreateBatch("b1", "GARISH-RUG", 100, None), uow)
         messagebus.handle(commands.CreateBatch("b2", "GARISH-RUG", 99, None), uow)
-        assert "b2" in [b.reference for b in uow.repo.get("GARISH-RUG").items]
+        assert "b2" in [b.reference for b in uow[Product].get("GARISH-RUG").items]
 
 
 class TestAllocate:
-    def test_returns_allocation(self, uow: FakeProductUnitOfWork):
+    def test_returns_allocation(self, uow: FakeUnitOfWork):
         messagebus.handle(
             commands.CreateBatch("batch1", "COMPLICATED-LAMP", 100, None), uow
         )
         result = messagebus.handle(commands.Allocate("o1", "COMPLICATED-LAMP", 10), uow)
         assert ["batch1"] == result
 
-    def test_errors_for_invalid_sku(self, uow: FakeProductUnitOfWork):
+    def test_errors_for_invalid_sku(self, uow: FakeUnitOfWork):
         messagebus.handle(commands.CreateBatch("b1", "AREALSKU", 100, None), uow)
 
         with pytest.raises(batch.InvalidSku, match="Invalid sku NONEXISTENTSKU"):
             messagebus.handle(commands.Allocate("o1", "NONEXISTENTSKU", 10), uow)
 
-    def test_commits(self, uow: FakeProductUnitOfWork):
+    def test_commits(self, uow: FakeUnitOfWork):
         messagebus.handle(commands.CreateBatch("b1", "OMINOUS-MIRROR", 100, None), uow)
         messagebus.handle(commands.Allocate("o1", "OMINOUS-MIRROR", 10), uow)
         assert uow.committed
 
     def test_sends_email_on_out_of_stock_error(
-        self, uow: FakeProductUnitOfWork, handlers: MessageHandlers
+        self, uow: FakeUnitOfWork, handlers: MessageHandlers
     ):
         messagebus = FakeMessageBus(handlers, fake_messages={events.OutOfStock})
         messagebus.handle(commands.CreateBatch("b1", "POPULAR-CURTAINS", 9, None), uow)
@@ -73,18 +71,18 @@ class TestAllocate:
 
 
 class TestChangeBatchQuantity:
-    def test_changes_available_quantity(self, uow: FakeProductUnitOfWork):
+    def test_changes_available_quantity(self, uow: FakeUnitOfWork):
         messagebus.handle(
             commands.CreateBatch("batch1", "ADORABLE-SETTEE", 100, None), uow
         )
-        [batch] = uow.repo.get("ADORABLE-SETTEE").items
+        [batch] = uow[Product].get("ADORABLE-SETTEE").items
         assert batch.available_quantity == 100
 
         messagebus.handle(commands.ChangeBatchQuantity("batch1", 50), uow)
 
         assert batch.available_quantity == 50
 
-    def test_reallocates_if_necessary(self, uow: FakeProductUnitOfWork):
+    def test_reallocates_if_necessary(self, uow: FakeUnitOfWork):
         message_history = [
             commands.CreateBatch("batch1", "INDIFFERENT-TABLE", 50, None),
             commands.CreateBatch("batch2", "INDIFFERENT-TABLE", 50, date.today()),
@@ -95,7 +93,7 @@ class TestChangeBatchQuantity:
         for e in message_history:
             messagebus.handle(e, uow)
 
-        [batch1, batch2] = uow.repo.get("INDIFFERENT-TABLE").items
+        [batch1, batch2] = uow[Product].get("INDIFFERENT-TABLE").items
         assert batch1.available_quantity == 10
         assert batch2.available_quantity == 50
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -11,16 +11,16 @@ from tests.app.domain.models import Batch
 
 
 def test_add_batch() -> None:
-    uow = FakeUnitOfWork(Product, "sku")
+    uow = FakeUnitOfWork({Product: "sku"})
     services.add_batch("b1", "CRUNCHY-ARMCHAIR", 100, None, uow)
-    assert uow.repo.get("CRUNCHY-ARMCHAIR") is not None
+    assert uow[Product].get("CRUNCHY-ARMCHAIR") is not None
     assert uow.committed
 
 
 def test_returns_allocation() -> None:
     batch = Batch("b1", "COMPLICATED-LAMP", 100, eta=None)
     product = Product(batch.sku, [batch])
-    uow = FakeUnitOfWork(Product, "sku", [product])
+    uow = FakeUnitOfWork({Product: "sku"}, [product])
     result = services.batch.allocate("o1", "COMPLICATED-LAMP", 10, uow)
     assert result == "b1"
 
@@ -28,7 +28,7 @@ def test_returns_allocation() -> None:
 def test_error_for_invalid_sku() -> None:
     batch = Batch("b1", "AREALSKU", 100, eta=None)
     product = Product(batch.sku, [batch])
-    uow = FakeUnitOfWork(Product, "sku", [product])
+    uow = FakeUnitOfWork({Product: "sku"}, [product])
     with pytest.raises(services.batch.InvalidSku, match="Invalid sku NONEXISTENTSKU"):
         services.batch.allocate("o1", "NONEXISTENTSKU", 10, uow)
 
@@ -36,20 +36,20 @@ def test_error_for_invalid_sku() -> None:
 def test_commits() -> None:
     batch = Batch("b1", "OMINOUS-MIRROR", 100, eta=None)
     product = Product(batch.sku, [batch])
-    uow = FakeUnitOfWork(Product, "sku", [product])
+    uow = FakeUnitOfWork({Product: "sku"}, [product])
     services.batch.allocate("o1", "OMINOUS-MIRROR", 10, uow)
     assert uow.committed is True
 
 
 def test_allocate_returns_allocation() -> None:
-    uow = FakeUnitOfWork(Product, "sku")
+    uow = FakeUnitOfWork({Product: "sku"})
     services.add_batch("batch1", "COMPLICATED-LAMP", 100, None, uow)
     result = services.batch.allocate("o1", "COMPLICATED-LAMP", 10, uow)
     assert "batch1" == result
 
 
 def test_allocate_errors_for_invalid_sku() -> None:
-    uow = FakeUnitOfWork(Product, "sku")
+    uow = FakeUnitOfWork({Product: "sku"})
     services.add_batch("b1", "AREALSKU", 100, None, uow)
     with pytest.raises(services.batch.InvalidSku, match="Invalid sku NONEXISTENTSKU"):
         services.batch.allocate("o1", "NONEXISTENTSKU", 10, uow)


### PR DESCRIPTION
@benzamin0 구조 개선건입니다.  리뷰 하시고 승인 부탁드립니다.

10장에서 UoW 에 `Product` 외에 `Customers`, `OrderHistory` 등 다양한 레포지터리가 추가되면서 구조 개선이 필요하게 된 건입니다. 

사용 방법입니다.

```python

uow = SqlAlchemyUnitOfWork([CustomerOrder, OrderHistory, Customer])

@on_command(CreateOrder)
def create_order_from_basket(cmd: CreateOrder, uow: AbstractUnitOfWork):
    with uow:
        order = Order.from_basket(cmd.customer_id, cmd.basket_items)
        uow[CustomerOrder].add(cast(CustomerOrder, order))
        uow.commit()  # raises OrderCreated


@on_event(OrderCreated)
def update_customer_history(event: OrderCreated, uow: AbstractUnitOfWork):
    with uow:
        history = uow[OrderHistory].get(event.customer_id)
        history.record_order(event.order_id, event.order_amount)
        uow.commit()  # raises CustomerBecameVIP


@on_event(CustomerBecameVIP)
def congratulate_vip_customer(event: CustomerBecameVIP, uow: AbstractUnitOfWork):
    with uow:
        customer = uow[Customer].get(event.customer_id)
        email.send(customer.email_address, f"Congratulations {customer.first_name}!")

```

- 관련 이슈: #6